### PR TITLE
Compile fix for MSVC 14

### DIFF
--- a/include/boost/signals2/detail/slot_template.hpp
+++ b/include/boost/signals2/detail/slot_template.hpp
@@ -28,7 +28,7 @@ namespace boost
     template<typename Signature, typename SlotFunction = boost::function<Signature> >
       class slot;
 
-#if BOOST_WORKAROUND(BOOST_MSVC, == 1800)
+#if BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
     template<typename Signature, typename SlotFunction> class slot{};
 #endif
 #endif // BOOST_NO_CXX11_VARIADIC_TEMPLATES


### PR DESCRIPTION
Enables the Visual C++ 12 workaround also for Visual C++ 14.
