### PR TITLE
Remove unused include

### DIFF
--- a/include/boost/signals2/deconstruct.hpp
+++ b/include/boost/signals2/deconstruct.hpp
@@ -26,7 +26,6 @@
 
 #include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/signals2/deconstruct_ptr.hpp>
 #include <boost/type_traits/alignment_of.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/type_with_alignment.hpp>


### PR DESCRIPTION
This header file does not compile with clang-cl because of the try/catch, and it's not used anyway since 44f2fc27d825482456f75673921d11cd71f904e4.
