### PR TITLE
Add missing include to signals2/trackable.hpp

### DIFF
--- a/include/boost/signals2/trackable.hpp
+++ b/include/boost/signals2/trackable.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
 
 namespace boost {
   namespace signals2 {


### PR DESCRIPTION
boost::weak_ptr started being used in commit a0bf2d1 (Disconnect slots
associated with signals2::trackable immediately) but the matching header
wasn't included.

https://svn.boost.org/trac/boost/ticket/10100#comment:7
