### PR TITLE
Fix TryEnterCriticalSection return type

### DIFF
--- a/include/boost/signals2/detail/lwm_win32_cs.hpp
+++ b/include/boost/signals2/detail/lwm_win32_cs.hpp
@@ -55,7 +55,7 @@ extern "C" __declspec(dllimport) void __stdcall InitializeCriticalSectionEx(crit
 extern "C" __declspec(dllimport) void __stdcall InitializeCriticalSection(critical_section *);
 #endif
 extern "C" __declspec(dllimport) void __stdcall EnterCriticalSection(critical_section *);
-extern "C" __declspec(dllimport) bool __stdcall TryEnterCriticalSection(critical_section *);
+extern "C" __declspec(dllimport) int __stdcall TryEnterCriticalSection(critical_section *);
 extern "C" __declspec(dllimport) void __stdcall LeaveCriticalSection(critical_section *);
 extern "C" __declspec(dllimport) void __stdcall DeleteCriticalSection(critical_section *);
 


### PR DESCRIPTION
TryEnterCriticalSection returns a BOOL, which is a typedef for int.