### PR TITLE
Remove unnecessary "extern" on some inline functions

### DIFF
--- a/include/boost/signals2/connection.hpp
+++ b/include/boost/signals2/connection.hpp
@@ -28,7 +28,7 @@ namespace boost
 {
   namespace signals2
   {
-    extern inline void null_deleter(const void*) {}
+    inline void null_deleter(const void*) {}
     namespace detail
     {
       // This lock maintains a list of shared_ptr<void>

--- a/include/boost/signals2/deconstruct_ptr.hpp
+++ b/include/boost/signals2/deconstruct_ptr.hpp
@@ -27,18 +27,18 @@ namespace boost
   {
     namespace detail
     {
-      extern inline void do_postconstruct(const postconstructible *ptr)
+      inline void do_postconstruct(const postconstructible *ptr)
       {
         postconstructible *nonconst_ptr = const_cast<postconstructible*>(ptr);
         nonconst_ptr->postconstruct();
       }
-      extern inline void do_postconstruct(...)
+      inline void do_postconstruct(...)
       {
       }
-      extern inline void do_predestruct(...)
+      inline void do_predestruct(...)
       {
       }
-      extern inline void do_predestruct(const predestructible *ptr)
+      inline void do_predestruct(const predestructible *ptr)
       {
         try
         {


### PR DESCRIPTION
There is an ancient compiler that (wrongly) rejects "etern inline".
http://am.renesas.com/products/tools/coding_tools/c_compilers_assemblers/sh_compiler/index.jsp

The removal is also good for consistency. There is no other occurrence
of "extern inline" throughout Boost source tree.