### PR TITLE
#11461: Enable some signals2 when exceptions disabled

### DIFF
--- a/include/boost/signals2/detail/slot_call_iterator.hpp
+++ b/include/boost/signals2/detail/slot_call_iterator.hpp
@@ -38,7 +38,7 @@ namespace boost {
           disconnected_slot_count(0),
           m_active_slot(0)
         {}
-        
+
         ~slot_call_iterator_cache()
         {
           if(m_active_slot)
@@ -47,9 +47,9 @@ namespace boost {
             m_active_slot->dec_slot_refcount(lock);
           }
         }
-        
+
         template<typename M>
-        void set_active_slot(garbage_collecting_lock<M> &lock, 
+        void set_active_slot(garbage_collecting_lock<M> &lock,
           connection_body_base *active_slot)
         {
           if(m_active_slot)
@@ -58,7 +58,7 @@ namespace boost {
           if(m_active_slot)
             m_active_slot->inc_slot_refcount(lock);
         }
-        
+
         optional<ResultType> result;
         typedef auto_buffer<void_shared_ptr_variant, store_n_objects<10> > tracked_ptrs_type;
         tracked_ptrs_type tracked_ptrs;
@@ -104,15 +104,16 @@ namespace boost {
         dereference() const
         {
           if (!cache->result) {
-            try
+            BOOST_TRY
             {
               cache->result.reset(cache->f(*iter));
             }
-            catch(expired_slot &)
+            BOOST_CATCH(expired_slot &)
             {
               (*iter)->disconnect();
-              throw;
+              BOOST_RETHROW
             }
+            BOOST_CATCH_END
           }
           return cache->result.get();
         }
@@ -140,7 +141,7 @@ namespace boost {
           else
             cache->set_active_slot(lock, (*callable_iter).get());
         }
-        
+
         void lock_next_callable() const
         {
           if(iter == callable_iter)

--- a/include/boost/signals2/optional_last_value.hpp
+++ b/include/boost/signals2/optional_last_value.hpp
@@ -29,11 +29,12 @@ namespace boost {
         optional<T> value;
         while (first != last)
         {
-          try
+          BOOST_TRY
           {
             value = *first;
           }
-          catch(const expired_slot &) {}
+          BOOST_CATCH(const expired_slot &) {}
+          BOOST_CATCH_END
           ++first;
         }
         return value;
@@ -50,11 +51,12 @@ namespace boost {
       {
         while (first != last)
         {
-          try
+          BOOST_TRY
           {
             *first;
           }
-          catch(const expired_slot &) {}
+          BOOST_CATCH(const expired_slot &) {}
+          BOOST_CATCH_END
           ++first;
         }
         return;

--- a/include/boost/signals2/slot_base.hpp
+++ b/include/boost/signals2/slot_base.hpp
@@ -67,6 +67,7 @@ namespace boost
       typedef std::vector<detail::void_shared_ptr_variant> locked_container_type;
 
       const tracked_container_type& tracked_objects() const {return _tracked_objects;}
+    #if(!BOOST_NO_EXCEPTIONS)
       locked_container_type lock() const
       {
         locked_container_type locked_objects;
@@ -81,6 +82,7 @@ namespace boost
         }
         return locked_objects;
       }
+    #endif
       bool expired() const
       {
         tracked_container_type::const_iterator it;


### PR DESCRIPTION
This allows signals2 to be used when exception support is disabled by
removing certain functionality. If that functionality is used it should
give a compilation error and can be fixed at that time or another
workaround used.

This gives a partial fix for issue https://svn.boost.org/trac/boost/ticket/11461

I have an interest in making signals2 work without exceptions, but it wasn't clear what needed to be done.  I started by removing the offending throw function, and didn't see a missing function error, so I figured at least some of the functionality could run without having exceptions.

I would like any comments about this, how I could improve it and/or what functionality is broken by it.