### PR TITLE
slot_base.hpp: clang gives compiler errors in boost 1.62

### DIFF
--- a/include/boost/signals2/slot_base.hpp
+++ b/include/boost/signals2/slot_base.hpp
@@ -67,7 +67,7 @@ namespace boost
       typedef std::vector<detail::void_shared_ptr_variant> locked_container_type;
 
       const tracked_container_type& tracked_objects() const {return _tracked_objects;}
-    #ifdef BOOST_NO_EXCEPTIONS
+    #ifndef BOOST_NO_EXCEPTIONS
       locked_container_type lock() const
       {
         locked_container_type locked_objects;

--- a/include/boost/signals2/slot_base.hpp
+++ b/include/boost/signals2/slot_base.hpp
@@ -67,7 +67,7 @@ namespace boost
       typedef std::vector<detail::void_shared_ptr_variant> locked_container_type;
 
       const tracked_container_type& tracked_objects() const {return _tracked_objects;}
-    #if(!BOOST_NO_EXCEPTIONS)
+    #ifdef BOOST_NO_EXCEPTIONS
       locked_container_type lock() const
       {
         locked_container_type locked_objects;


### PR DESCRIPTION
I am trying to update to boost-1.62 but am hitting compiler errors:

/usr/local/include/boost/signals2/slot_base.hpp:70:29: error: expected value in expression
    #if(!BOOST_NO_EXCEPTIONS)
                            ^