### PR TITLE
fix a mistake in postconstructor_invoker<T>::postconstruct()

### DIFF
--- a/include/boost/signals2/deconstruct.hpp
+++ b/include/boost/signals2/deconstruct.hpp
@@ -64,7 +64,7 @@ public:
     }
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     template<class... Args>
-      const shared_ptr<T>& postconstruct(Args && ... args)
+      const shared_ptr<T>& postconstruct(Args && ... args) const
     {
         if(!_postconstructed)
         {


### PR DESCRIPTION
The variadic function template  `postconstructor_invoker<T>::postconstruct()` without const modifier.