### PR TITLE
fix a bug in boost::signals2::detail::operator<=()

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -1116,7 +1116,7 @@ namespace detail
     inline bool operator<=( const auto_buffer<T,SBP,GP,A>& l,
                             const auto_buffer<T,SBP,GP,A>& r )
     {
-        return !(r > l);
+        return !(l > r);
     }
 
     template< class T, class SBP, class GP, class A >


### PR DESCRIPTION
`l <= r` equals `!(l > r)`