### PR TITLE
Remove incorrectly included hello world example

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -36,10 +36,11 @@ make hello_world_def_code_snippet.xml
 
 ###############################################################################
 alias boostdoc
-    : signals.xml hello_world_def_code_snippet.xml
+    : signals.xml
     :
     :
-    : <implicit-dependency>hello_world_def_code_snippet.xml ;
+    : <implicit-dependency>hello_world_def_code_snippet.xml
+      <dependency>hello_world_def_code_snippet.xml ;
 explicit boostdoc ;
 alias boostrelease ;
 explicit boostrelease ;


### PR DESCRIPTION
A 'HelloWorld' example from the documentation is appearing at
the bottom of the contents page:

http://www.boost.org/doc/libs/1_63_0/doc/html/libraries.html

I think this will remove it, although it won't be clear until the change
is checked into develop and the documentation rebuilt.