### PR TITLE
conditionally replace removed c++98 std::bind1st by c++11 std::bind

### DIFF
--- a/test/signal_test.cpp
+++ b/test/signal_test.cpp
@@ -133,7 +133,11 @@ test_one_arg()
   boost::signals2::signal<int (int value), max_or_default<int> > s1;
 
   s1.connect(std::negate<int>());
+#if !defined(BOOST_NO_CXX98_BINDERS)
   s1.connect(std::bind1st(std::multiplies<int>(), 2));
+#elif !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+  s1.connect(std::bind(std::multiplies<int>(), 2, std::placeholders::_1));
+#endif
 
   BOOST_CHECK(s1(1) == 2);
   BOOST_CHECK(s1(-1) == 1);
@@ -152,8 +156,13 @@ test_signal_signal_connect()
   {
     signal_type s2;
     s1.connect(s2);
+#if !defined(BOOST_NO_CXX98_BINDERS)
     s2.connect(std::bind1st(std::multiplies<int>(), 2));
     s2.connect(std::bind1st(std::multiplies<int>(), -3));
+#elif !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    s2.connect(std::bind(std::multiplies<int>(), 2, std::placeholders::_1));
+    s2.connect(std::bind(std::multiplies<int>(), -3, std::placeholders::_1));
+#endif
 
     BOOST_CHECK(s2(-3) == 9);
     BOOST_CHECK(s1(3) == 6);


### PR DESCRIPTION
Signed-off-by: Daniela Engert <dani@ngrt.de>