### PR TITLE
Fix maybe uninitialized warnings with gcc 7.

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -248,6 +248,14 @@ namespace detail
             auto_buffer_destroy( where, boost::has_trivial_destructor<T>() );
         }
 
+        void auto_buffer_destroy()
+        {
+            BOOST_ASSERT( is_valid() );
+            if( buffer_ ) // do we need this check? Yes, but only
+                // for N = 0u + local instances in one_sided_swap()
+                auto_buffer_destroy( boost::has_trivial_destructor<T>() );
+        }
+
         void destroy_back_n( size_type n, const boost::false_type& )
         {
             BOOST_ASSERT( n > 0 );
@@ -301,7 +309,7 @@ namespace detail
         {
             pointer new_buffer = move_to_new_buffer( new_capacity,
                                                  boost::has_nothrow_copy<T>() );
-            (*this).~auto_buffer();
+            auto_buffer_destroy();
             buffer_   = new_buffer;
             members_.capacity_ = new_capacity;
             BOOST_ASSERT( size_ <= members_.capacity_ );
@@ -355,7 +363,7 @@ namespace detail
         void one_sided_swap( auto_buffer& temp ) // nothrow
         {
             BOOST_ASSERT( !temp.is_on_stack() );
-            this->~auto_buffer();
+            auto_buffer_destroy();
             // @remark: must be nothrow
             get_allocator()    = temp.get_allocator();
             members_.capacity_ = temp.members_.capacity_;
@@ -506,7 +514,7 @@ namespace detail
                 {
                     // @remark: we release memory as early as possible
                     //          since we only give the basic guarantee
-                    (*this).~auto_buffer();
+                    auto_buffer_destroy();
                     buffer_ = 0;
                     pointer new_buffer = allocate( r.size() );
                     boost::multi_index::detail::scope_guard guard =
@@ -597,10 +605,7 @@ namespace detail
 
         ~auto_buffer()
         {
-            BOOST_ASSERT( is_valid() );
-            if( buffer_ ) // do we need this check? Yes, but only
-                // for N = 0u + local instances in one_sided_swap()
-                auto_buffer_destroy( boost::has_trivial_destructor<T>() );
+            auto_buffer_destroy();
         }
 
     public:
@@ -1033,7 +1038,7 @@ namespace detail
                 pointer new_buffer = static_cast<T*>(other->members_.address());
                 copy_impl( one_on_stack->begin(), one_on_stack->end(),
                            new_buffer );                            // strong
-                one_on_stack->~auto_buffer();                       // nothrow
+                one_on_stack->auto_buffer_destroy();                       // nothrow
                 boost::swap( get_allocator(), r.get_allocator() );  // assume nothrow
                 boost::swap( members_.capacity_, r.members_.capacity_ );
                 boost::swap( size_, r.size_ );


### PR DESCRIPTION
Hi,

I am having new warnings when migration to gcc 7. With -Wall -Wextra -Werror I have this when using the library very basically:

```
/remote/mw/combld/delivery/unofficial.17/components.osp/osp/Boost/17-0-0-0/include/boost/signals2/detail/auto_buffer.hpp:307:27: error: ‘local_lock.boost::signals2::detail::auto_buf
fer<boost::shared_ptr<void>, boost::signals2::detail::store_n_objects<10> >::size_’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             BOOST_ASSERT( size_ <= members_.capacity_ );
                           ^~~~~
```

when looking a bit to the code, this seems linked to the fact that you often call the destructor of "this" and continue to use it afterwards, which apparently gcc doesn't like despite that all the auto_buffer members are normally trivially destructible (while auto_buffer itself might not be if storing a non trivially destructible type). Moving the destruction into it's own method rather than the destructor helps gcc to understand everything correctly.

Cheers,
Romain