### PR TITLE
Fix compilation issue with -fno-exceptions

### DIFF
--- a/include/boost/signals2/detail/slot_template.hpp
+++ b/include/boost/signals2/detail/slot_template.hpp
@@ -103,12 +103,16 @@ namespace boost
       // invocation
       R operator()(BOOST_SIGNALS2_SIGNATURE_FULL_ARGS(BOOST_SIGNALS2_NUM_ARGS))
       {
+#ifndef BOOST_NO_EXCEPTIONS
         locked_container_type locked_objects = lock();
+#endif
         return _slot_function(BOOST_SIGNALS2_SIGNATURE_ARG_NAMES(BOOST_SIGNALS2_NUM_ARGS));
       }
       R operator()(BOOST_SIGNALS2_SIGNATURE_FULL_ARGS(BOOST_SIGNALS2_NUM_ARGS)) const
       {
+#ifndef BOOST_NO_EXCEPTIONS
         locked_container_type locked_objects = lock();
+#endif
         return _slot_function(BOOST_SIGNALS2_SIGNATURE_ARG_NAMES(BOOST_SIGNALS2_NUM_ARGS));
       }
       // tracking


### PR DESCRIPTION
Double-posting from the mailing list:

Trying to compile any program that includes boost/signals2 with -fno-exceptions fails as of 1.64:

#include <boost/signals2.hpp>
// boost/signals2/slot.hpp will also reproduce the error

int main()
{
}

g++ prog.cc -I<path to Boost 1.64.0 headers> -std=c++11 -fno-exceptions

View it on Wandbox:
https://wandbox.org/permlink/vZVpF5bb8E9K7sDz

I was also able to reproduce this locally on the develop branch.

I'm not sure if avoiding the lock functions when exceptions are turned off is a good idea or not, since I'm not intimately familiar with the inner workings of Signals2. Feedback welcome. I was also unable to figure out how to build the test suite for this library because I'm not familiar with Boost.Build.