### PR TITLE
Internalize scope_guard from Boost.MultiIndex

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -21,7 +21,7 @@
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/multi_index/detail/scope_guard.hpp>
+#include <boost/signals2/detail/scope_guard.hpp>
 #include <boost/swap.hpp>
 #include <boost/type_traits/aligned_storage.hpp>
 #include <boost/type_traits/alignment_of.hpp>
@@ -288,11 +288,10 @@ namespace detail
         pointer move_to_new_buffer( size_type new_capacity, const boost::false_type& )
         {
             pointer new_buffer = allocate( new_capacity ); // strong
-            boost::multi_index::detail::scope_guard guard =
-                boost::multi_index::detail::make_obj_guard( *this,
-                                                            &auto_buffer::deallocate,
-                                                            new_buffer,
-                                                            new_capacity );
+            scope_guard guard = make_obj_guard( *this,
+                                                &auto_buffer::deallocate,
+                                                new_buffer,
+                                                new_capacity );
             copy_impl( begin(), end(), new_buffer ); // strong
             guard.dismiss();                         // nothrow
             return new_buffer;
@@ -517,11 +516,10 @@ namespace detail
                     auto_buffer_destroy();
                     buffer_ = 0;
                     pointer new_buffer = allocate( r.size() );
-                    boost::multi_index::detail::scope_guard guard =
-                        boost::multi_index::detail::make_obj_guard( *this,
-                                                                    &auto_buffer::deallocate,
-                                                                    new_buffer,
-                                                                    r.size() );
+                    scope_guard guard = make_obj_guard( *this,
+                                                        &auto_buffer::deallocate,
+                                                        new_buffer,
+                                                        r.size() );
                     copy_impl( r.begin(), r.end(), new_buffer );
                     guard.dismiss();
                     buffer_            = new_buffer;

--- a/include/boost/signals2/detail/scope_guard.hpp
+++ b/include/boost/signals2/detail/scope_guard.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2003-2013 Joaquin M Lopez Munoz.
+ *           2019 Mike Dev <mike.dev@gmx.de>
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * https://www.boost.org/LICENSE_1_0.txt)
+ *
+ * NOTE: internalized from Boost.MultiIndex
+ *
+ */
+
+
+#ifndef BOOST_SIGNALS2_DETAIL_SCOPE_GUARD_HPP
+#define BOOST_SIGNALS2_DETAIL_SCOPE_GUARD_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/core/no_exceptions_support.hpp>
+
+namespace boost{
+
+namespace signals2{
+
+namespace detail{
+
+/* This is a merely reformated version of
+ * ScopeGuard.h as defined in:
+ *   Alexandrescu, A., Marginean, P.:"Generic<Programming>: Change the Way You
+ *     Write Exception-Safe Code - Forever", C/C++ Users Jornal, Dec 2000,
+ *     http://www.drdobbs.com/184403758
+ * with the following modifications:
+ *   - General pretty formatting (pretty to my taste at least.)
+ *   - Naming style changed to standard C++ library requirements.
+ *   - Removed RefHolder and ByRef, whose functionality is provided
+ *     already by Boost.Ref.
+ *   - Removed static make_guard's and make_obj_guard's, so that the code
+ *     will work even if BOOST_NO_MEMBER_TEMPLATES is defined. This forces
+ *     us to move some private ctors to public, though.
+ *
+ * NB: CodeWarrior Pro 8 seems to have problems looking up safe_execute
+ * without an explicit qualification.
+ *
+ *  TODO: Consider replacing with Boost.ScopeExit
+ *
+ */
+
+class scope_guard_impl_base
+{
+public:
+  scope_guard_impl_base():dismissed_(false){}
+  void dismiss()const{dismissed_=true;}
+
+protected:
+  ~scope_guard_impl_base(){}
+
+  scope_guard_impl_base(const scope_guard_impl_base& other):
+    dismissed_(other.dismissed_)
+  {
+    other.dismiss();
+  }
+
+  template<typename J>
+  static void safe_execute(J& j){
+    BOOST_TRY{
+      if(!j.dismissed_)j.execute();
+    }
+    BOOST_CATCH(...){}
+    BOOST_CATCH_END
+  }
+
+  mutable bool dismissed_;
+
+private:
+  scope_guard_impl_base& operator=(const scope_guard_impl_base&);
+};
+
+typedef const scope_guard_impl_base& scope_guard;
+
+template<class Obj,typename MemFun,typename P1,typename P2>
+class obj_scope_guard_impl2:public scope_guard_impl_base
+{
+public:
+  obj_scope_guard_impl2(Obj& obj,MemFun mem_fun,P1 p1,P2 p2):
+    obj_(obj),mem_fun_(mem_fun),p1_(p1),p2_(p2)
+  {}
+  ~obj_scope_guard_impl2(){scope_guard_impl_base::safe_execute(*this);}
+  void execute(){(obj_.*mem_fun_)(p1_,p2_);}
+
+protected:
+  Obj&     obj_;
+  MemFun   mem_fun_;
+  const P1 p1_;
+  const P2 p2_;
+};
+
+template<class Obj,typename MemFun,typename P1,typename P2>
+inline obj_scope_guard_impl2<Obj,MemFun,P1,P2>
+make_obj_guard(Obj& obj,MemFun mem_fun,P1 p1,P2 p2)
+{
+  return obj_scope_guard_impl2<Obj,MemFun,P1,P2>(obj,mem_fun,p1,p2);
+}
+
+} /* namespace signals2::detail */
+
+} /* namespace signals2 */
+
+} /* namespace boost */
+
+#endif


### PR DESCRIPTION
scope_guard is an implementation detail of multi index and other libraries should not depend on it.

I copy pased only the relevant parts used in boost signals. 

As a side-effect this reduces significantly the number of (indirect) dependencies of Boost.Signals2 (67-> 29) as seen by boostdep and package management tools like vcpkg and conan, because Boost.MultiIndex has a dependency on Boost.Serialization.  

An even better solution might be to use Boost.Scope_exit but I'm not familiar with that library and didn't want to mess with the Boost.Signals2 sources more than necessary. So this seemed to be the simples solution. 