### PR TITLE
Remove cppcheck job on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,13 +147,6 @@ jobs:
 
     - os: linux
       env:
-        - COMMENT=cppcheck
-      script:
-        - cd $BOOST_ROOT/libs/$SELF
-        - ci/travis/cppcheck.sh
-
-    - os: linux
-      env:
         - COMMENT=ubsan
         - B2_VARIANT=variant=debug
         - B2_TOOLSET=gcc-8


### PR DESCRIPTION
It was hanging and we're not getting any value out of it.  Removed it from the CI builds.