### PR TITLE
Fix using signals2 with gcc 10 and --std=gnu++20: deprecated std::all…

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -142,7 +142,11 @@ namespace detail
         typedef typename Allocator::size_type            size_type;
         typedef typename Allocator::difference_type      difference_type;
         typedef T*                                       pointer;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename Allocator::pointer              allocator_pointer;
+#else
+        typedef typename std::allocator_traits<Allocator>::pointer allocator_pointer;
+#endif
         typedef const T*                                 const_pointer;
         typedef T&                                       reference;
         typedef const T&                                 const_reference;


### PR DESCRIPTION
…ocator member access.

In C++20, the member "pointer" has been removed. However it's still defined in std::allocator_traits.