### PR TITLE
Use allocator access utilities from Boost.Core

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
+#include <boost/core/allocator_access.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/mpl/if.hpp>
@@ -140,14 +141,10 @@ namespace detail
     public:
         typedef Allocator                                allocator_type;
         typedef T                                        value_type;
-        typedef typename Allocator::size_type            size_type;
-        typedef typename Allocator::difference_type      difference_type;
+        typedef typename boost::allocator_size_type<Allocator>::type size_type;
+        typedef typename boost::allocator_difference_type<Allocator>::type difference_type;
         typedef T*                                       pointer;
-#ifdef BOOST_NO_CXX11_ALLOCATOR
-        typedef typename Allocator::pointer              allocator_pointer;
-#else
-        typedef typename std::allocator_traits<Allocator>::pointer allocator_pointer;
-#endif
+        typedef typename boost::allocator_pointer<Allocator>::type allocator_pointer;
         typedef const T*                                 const_pointer;
         typedef T&                                       reference;
         typedef const T&                                 const_reference;


### PR DESCRIPTION
Should resolve issue #46. 