### PR TITLE
refactor: avoid using deprecated Boost headers

### DIFF
--- a/example/doc_view_acm_deconstruct.cpp
+++ b/example/doc_view_acm_deconstruct.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <string>
 #include <boost/bind/bind.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/signals2/deconstruct.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/shared_ptr.hpp>

--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -20,11 +20,11 @@
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/core/allocator_access.hpp>
+#include <boost/core/swap.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/signals2/detail/scope_guard.hpp>
-#include <boost/swap.hpp>
 #include <boost/type_traits/aligned_storage.hpp>
 #include <boost/type_traits/alignment_of.hpp>
 #include <boost/type_traits/has_nothrow_copy.hpp>

--- a/include/boost/signals2/detail/signals_common.hpp
+++ b/include/boost/signals2/detail/signals_common.hpp
@@ -11,9 +11,9 @@
 #ifndef BOOST_SIGNALS2_SIGNALS_COMMON_HPP
 #define BOOST_SIGNALS2_SIGNALS_COMMON_HPP
 
+#include <boost/core/ref.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/ref.hpp>
 #include <boost/signals2/signal_base.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 

--- a/include/boost/signals2/detail/tracked_objects_visitor.hpp
+++ b/include/boost/signals2/detail/tracked_objects_visitor.hpp
@@ -12,8 +12,8 @@
 #ifndef BOOST_SIGNALS2_TRACKED_OBJECTS_VISITOR_HPP
 #define BOOST_SIGNALS2_TRACKED_OBJECTS_VISITOR_HPP
 
+#include <boost/core/ref.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/ref.hpp>
 #include <boost/signals2/detail/signals_common.hpp>
 #include <boost/signals2/slot_base.hpp>
 #include <boost/signals2/trackable.hpp>

--- a/include/boost/signals2/slot.hpp
+++ b/include/boost/signals2/slot.hpp
@@ -14,9 +14,9 @@
 
 #include <boost/bind/bind.hpp>
 #include <boost/config.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/function.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/ref.hpp>
 #include <boost/signals2/detail/signals_common.hpp>
 #include <boost/signals2/detail/signals_common_macros.hpp>
 #include <boost/signals2/detail/tracked_objects_visitor.hpp>

--- a/test/signal_n_test.cpp
+++ b/test/signal_n_test.cpp
@@ -20,8 +20,8 @@ BOOST_AUTO_TEST_CASE(test_main)
 }
 #else // BOOST_NO_CXX11_VARIADIC_TEMPLATES
 
+#include <boost/core/ref.hpp>
 #include <boost/optional.hpp>
-#include <boost/ref.hpp>
 #include <boost/signals2.hpp>
 #include <functional>
 

--- a/test/track_test.cpp
+++ b/test/track_test.cpp
@@ -10,8 +10,8 @@
 // For more information, see http://www.boost.org
 
 #include <memory>
+#include <boost/core/ref.hpp>
 #include <boost/optional.hpp>
-#include <boost/ref.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2.hpp>
 #define BOOST_TEST_MODULE track_test

--- a/test/trackable_test.cpp
+++ b/test/trackable_test.cpp
@@ -14,7 +14,7 @@
 #define BOOST_TEST_MODULE trackable_test
 #include <boost/test/included/unit_test.hpp>
 #include <boost/bind/bind.hpp>
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/weak_ptr.hpp>
 
 using namespace boost::placeholders;


### PR DESCRIPTION
`boost/ref.hpp` and `boost/swap.hpp` are both deprecated:
```cpp
#ifndef BOOST_REF_HPP
#define BOOST_REF_HPP

// The header file at this path is deprecated;
// use boost/core/ref.hpp instead.

#include <boost/core/ref.hpp>

#endif
```

```cpp
#ifndef BOOST_SWAP_HPP
#define BOOST_SWAP_HPP

// The header file at this path is deprecated;
// use boost/core/swap.hpp instead.

#include <boost/core/swap.hpp>

#endif
```