### PR TITLE
refactor: use core/checked_delete.hpp over checked_delete.hpp

### DIFF
--- a/include/boost/signals2/deconstruct_ptr.hpp
+++ b/include/boost/signals2/deconstruct_ptr.hpp
@@ -16,7 +16,7 @@
 #define BOOST_SIGNALS2_DECONSTRUCT_PTR_HPP
 
 #include <boost/assert.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/signals2/postconstructible.hpp>
 #include <boost/signals2/predestructible.hpp>


### PR DESCRIPTION
The later is deprecated.

```cpp
#ifndef BOOST_CHECKED_DELETE_HPP
#define BOOST_CHECKED_DELETE_HPP

// The header file at this path is deprecated;
// use boost/core/checked_delete.hpp instead.

#include <boost/core/checked_delete.hpp>

#endif
```