### PR TITLE
refactor: use type_traits/aligned_storage

### DIFF
--- a/include/boost/signals2/detail/slot_call_iterator.hpp
+++ b/include/boost/signals2/detail/slot_call_iterator.hpp
@@ -13,7 +13,6 @@
 #define BOOST_SIGNALS2_SLOT_CALL_ITERATOR_HPP
 
 #include <boost/assert.hpp>
-#include <boost/aligned_storage.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/optional.hpp>
@@ -24,6 +23,7 @@
 #include <boost/signals2/detail/unique_lock.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
+#include <boost/type_traits/aligned_storage.hpp>
 #include <boost/weak_ptr.hpp>
 
 namespace boost {


### PR DESCRIPTION
`boost/aligned_storage.hpp` just includes #includes <boost/type_traits/aligned_storage.hpp>.