### PR TITLE
refactor: use core/noncopyable over boost/noncopyable

### DIFF
--- a/include/boost/signals2/connection.hpp
+++ b/include/boost/signals2/connection.hpp
@@ -15,9 +15,9 @@
 #define BOOST_SIGNALS2_CONNECTION_HPP
 
 #include <boost/config.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/mpl/bool.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2/detail/auto_buffer.hpp>
 #include <boost/signals2/detail/null_output_iterator.hpp>

--- a/include/boost/signals2/detail/unique_lock.hpp
+++ b/include/boost/signals2/detail/unique_lock.hpp
@@ -12,7 +12,7 @@
 #ifndef BOOST_SIGNALS2_UNIQUE_LOCK_HPP
 #define BOOST_SIGNALS2_UNIQUE_LOCK_HPP
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 
 namespace boost
 {

--- a/include/boost/signals2/signal.hpp
+++ b/include/boost/signals2/signal.hpp
@@ -15,9 +15,9 @@
 #include <algorithm>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2/connection.hpp>
 #include <boost/signals2/detail/unique_lock.hpp>

--- a/include/boost/signals2/signal_base.hpp
+++ b/include/boost/signals2/signal_base.hpp
@@ -11,7 +11,7 @@
 #ifndef BOOST_SIGNALS2_SIGNAL_BASE_HPP
 #define BOOST_SIGNALS2_SIGNAL_BASE_HPP
 
-#include <boost/noncopyable.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace boost {


### PR DESCRIPTION
The later is deprecated
```cpp
#ifndef BOOST_NONCOPYABLE_HPP
#define BOOST_NONCOPYABLE_HPP

// The header file at this path is deprecated;
// use boost/core/noncopyable.hpp instead.

#include <boost/core/noncopyable.hpp>

#endif
```