### PR TITLE
Switch to `boost::core::invoke_swap`

### DIFF
--- a/include/boost/signals2/detail/auto_buffer.hpp
+++ b/include/boost/signals2/detail/auto_buffer.hpp
@@ -20,7 +20,7 @@
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/core/allocator_access.hpp>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/mpl/if.hpp>
@@ -332,8 +332,8 @@ namespace detail
             auto_buffer temp( l.begin(), l.end() );
             assign_impl( r.begin(), r.end(), l.begin() );
             assign_impl( temp.begin(), temp.end(), r.begin() );
-            boost::swap( l.size_, r.size_ );
-            boost::swap( l.members_.capacity_, r.members_.capacity_ );
+            boost::core::invoke_swap( l.size_, r.size_ );
+            boost::core::invoke_swap( l.members_.capacity_, r.members_.capacity_ );
         }
 
         static void swap_helper( auto_buffer& l, auto_buffer& r,
@@ -352,13 +352,13 @@ namespace detail
 
             size_type i = 0u;
             for(  ; i < min_size; ++i )
-                boost::swap( (*smallest)[i], (*largest)[i] );
+                boost::core::invoke_swap( (*smallest)[i], (*largest)[i] );
 
             for( ; i < max_size; ++i )
                 smallest->unchecked_push_back( (*largest)[i] );
 
             largest->pop_back_n( diff );
-            boost::swap( l.members_.capacity_, r.members_.capacity_ );
+            boost::core::invoke_swap( l.members_.capacity_, r.members_.capacity_ );
         }
 
         void one_sided_swap( auto_buffer& temp ) // nothrow
@@ -1014,10 +1014,10 @@ namespace detail
             bool both_on_heap  = !on_stack && !r_on_stack;
             if( both_on_heap )
             {
-                boost::swap( get_allocator(), r.get_allocator() );
-                boost::swap( members_.capacity_, r.members_.capacity_ );
-                boost::swap( buffer_, r.buffer_ );
-                boost::swap( size_, r.size_ );
+                boost::core::invoke_swap( get_allocator(), r.get_allocator() );
+                boost::core::invoke_swap( members_.capacity_, r.members_.capacity_ );
+                boost::core::invoke_swap( buffer_, r.buffer_ );
+                boost::core::invoke_swap( size_, r.size_ );
                 BOOST_ASSERT( is_valid() );
                 BOOST_ASSERT( r.is_valid() );
                 return;
@@ -1039,9 +1039,9 @@ namespace detail
                 copy_impl( one_on_stack->begin(), one_on_stack->end(),
                            new_buffer );                            // strong
                 one_on_stack->auto_buffer_destroy();                       // nothrow
-                boost::swap( get_allocator(), r.get_allocator() );  // assume nothrow
-                boost::swap( members_.capacity_, r.members_.capacity_ );
-                boost::swap( size_, r.size_ );
+                boost::core::invoke_swap( get_allocator(), r.get_allocator() );  // assume nothrow
+                boost::core::invoke_swap( members_.capacity_, r.members_.capacity_ );
+                boost::core::invoke_swap( size_, r.size_ );
                 one_on_stack->buffer_ = other->buffer_;
                 other->buffer_        = new_buffer;
                 BOOST_ASSERT( other->is_on_stack() );

--- a/include/boost/signals2/detail/foreign_ptr.hpp
+++ b/include/boost/signals2/detail/foreign_ptr.hpp
@@ -13,7 +13,7 @@
 
 #include <algorithm>
 #include <boost/config.hpp>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/assert.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/smart_ptr/bad_weak_ptr.hpp>
@@ -103,7 +103,7 @@ namespace boost
         }
         void swap(foreign_void_shared_ptr &other)
         {
-          boost::swap(_p, other._p);
+          boost::core::invoke_swap(_p, other._p);
         }
       private:
         foreign_shared_ptr_impl_base *_p;
@@ -159,7 +159,7 @@ namespace boost
         }
         void swap(foreign_void_weak_ptr &other)
         {
-          boost::swap(_p, other._p);
+          boost::core::invoke_swap(_p, other._p);
         }
         foreign_void_shared_ptr lock() const
         {


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.