### PR TITLE
Fix unused parameter warning in detail/signal_template.hpp

### DIFF
--- a/include/boost/signals2/detail/signal_template.hpp
+++ b/include/boost/signals2/detail/signal_template.hpp
@@ -775,7 +775,7 @@ namespace boost
     private:
       // explicit private copy constructor to avoid compiler trying to do implicit conversions to signal
       explicit BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS)(
-        const BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS) & other) BOOST_NOEXCEPT
+        const BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS) &) BOOST_NOEXCEPT
       {
           // noncopyable
           BOOST_ASSERT(false);


### PR DESCRIPTION
Clang 20 with -Wall -Wextra -Werror and Boost 1.88 raises this warning/error:

```
/data/mwrep/res/osp/Boost/25-0-0-0/include/boost/signals2/detail/signal_template.hpp:778:75: error: unused parameter 'other' [-Werror,-Wunused-parameter]
  778 |         const BOOST_SIGNALS2_SIGNAL_CLASS_NAME(BOOST_SIGNALS2_NUM_ARGS) & other) BOOST_NOEXCEPT
      |                                                                           ^
1 error generated.
```