### PR TITLE
Set CI B2_CI_VERSION=0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -8,7 +8,7 @@
 # As the yaml syntax for Drone CI is rather limited.
 #
 #
-globalenv={'B2_VARIANT': 'variant=release,debug'}
+globalenv={'B2_CI_VERSION': '0', 'B2_VARIANT': 'variant=release,debug'}
 linuxglobalimage="cppalliance/droneubuntu1604:1"
 windowsglobalimage="cppalliance/dronevs2019"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ environment:
     # B2_LINK: link=shared,static
     # B2_THREADING: threading=multi,single
     B2_VARIANT: variant=release,debug
+    B2_CI_VERSION: 0
 
   matrix:
     - FLAVOR: Visual Studio 2017 C++2a Strict


### PR DESCRIPTION
Hi,

Going back some years, boostorg/boost-ci provided a new way to configure B2 variables, which takes effect using B2_CI_VERSION=1. For example:

(new) 'B2_LINKFLAGS': '-fuse-ld=gold'

instead of

(previous) 'B2_LINKFLAGS': 'linkflags=-fuse-ld=gold'

Now that most boost libraries have migrated, we'd like to standardize boost-ci onto B2_CI_VERSION=1.

You can opt-out by configuring B2_CI_VERSION=0 and then upgrade later.

This pull request sets B2_CI_VERSION=0, so CI will continue to work, using the previous method.