### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -33,7 +33,6 @@ variant
 
 # Secondary dependencies
 
-static_assert
 concept_check
 detail
 function_types


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.