### PR TITLE
Don't require optional_last_value's result type to be assignable

### DIFF
--- a/include/boost/signals2/detail/slot_call_iterator.hpp
+++ b/include/boost/signals2/detail/slot_call_iterator.hpp
@@ -105,7 +105,7 @@ namespace boost {
           if (!cache->result) {
             BOOST_TRY
             {
-              cache->result = cache->f(*iter);
+              cache->result.emplace(cache->f(*iter));
             }
             BOOST_CATCH(expired_slot &)
             {

--- a/include/boost/signals2/optional_last_value.hpp
+++ b/include/boost/signals2/optional_last_value.hpp
@@ -33,7 +33,7 @@ namespace boost {
         {
           BOOST_TRY
           {
-            value = boost::move_if_not_lvalue_reference<T>(*first);
+            value.emplace(boost::move_if_not_lvalue_reference<T>(*first));
           }
           BOOST_CATCH(const expired_slot &) {}
           BOOST_CATCH_END


### PR DESCRIPTION
As in title. A move-constructible return type should suffice for `optional_last_value`.

Here's a minimal test-case demonstrating the issue:
```c++
#include <boost/signals2/signal.hpp>
#include <cassert>

struct moveonly_data
{
    moveonly_data(int data) : m_data(data){}
    moveonly_data(moveonly_data&&) = default;

    // The assignment operator should not be required here
    moveonly_data& operator=(moveonly_data&&) = default;

    moveonly_data(const moveonly_data&) = delete;
    moveonly_data& operator=(const moveonly_data&) = delete;
    int m_data;
};

moveonly_data moveonly_return_callback(int val)
{
    return {val+1};
}

int main()
{
    boost::signals2::signal<moveonly_data(int)> sig;
    sig.connect(moveonly_return_callback);
    int data{3};
    auto ret = sig(data);
    assert(ret->m_data == 4);
}
```

With this fix applied, the move-assignment operator can be deleted as expected.